### PR TITLE
Added/Configured Webpack and Workbox Plugins to 'webpack.config.js' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -18,12 +18,59 @@ module.exports = () => {
       path: path.resolve(__dirname, 'dist'),
     },
     plugins: [
-      
+
+      // HTML Webpack Plugin for generating the 'index.html' file while injecting our bundles
+      new HtmlWebpackPlugin({
+        template: './index.html',
+        title: 'JATE'
+      }),
+
+      // Workbox Webpack Plugin that injects our custom service worker into 'src-sw.js' file
+      new InjectManifest({
+        swSrc: './src-sw.js',
+        swDest: 'src-sw.js',
+      }),
+
+      // Webpack Manifest creates our 'manifest.json' file that allows us to add our CSS loaders and babel to webpack
+      new WebpackPwaManifest({
+        fingerprints: false,
+        inject: true,
+        name: 'Just Another Text Editor',
+        short_name: 'JATE',
+        description: 'Text Editor Application',
+        background_color: '#225ca3',
+        theme_color: '#225ca3',
+        start_url: './',
+        publicPath: './',
+        icons: [
+          {
+            src: path.resolve('src/images/logo.png'),
+            sizes: [96, 128, 192, 256, 384, 512],
+            destination: path.join('assets', 'icons'),
+          },
+        ],
+      }),
     ],
 
     module: {
+      // CSS loaders
       rules: [
-        
+        {
+          test: /\.css$/i,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.m?js$/,
+          exclude: /node_modules/,
+          // We use babel-loader in order to use ES6.
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+              plugins: ['@babel/plugin-proposal-object-rest-spread', '@babel/transform-runtime'],
+            },
+          },
+        },
       ],
     },
   };

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "start:dev": "",
-    "start": "",
-    "server": "",
-    "build": "",
-    "install": "",
-    "client": ""
+    "start:dev": "concurrently \"cd client && npm run build\" \"cd server && npm run server\" ",
+    "start": "npm run build && cd server && node server.js",
+    "server": "cd server server.js --ignore client",
+    "build": "cd client && npm run build",
+    "install": "cd server && npm i && cd ../client && npm i",
+    "client": "cd client && npm start"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
After adding in the starter code and reviewing module 19, Mini-Project and our previous Zoom meetings I decided to populate the 'webpack.config.js' file with what currently made sense (Utilizing HTMLWebpack and WorkboxWebpack Plugins, InjectManifest to create a 'manifest.json' file that enables us to use the CSS loaders and babel, etc.)

While also populating some missing commands/scripts within the 'package.json' file which are (and everything else that's been adjusted/added) subject to change.

To start I added in a `.gitignore` file that contains `node_modules` and `package-lock.json` to prevent all the contents from those files from being pushed up to the main repository as they are not needed in the main branch.

In `package.json` (the one that isn't in the client or server folder) I added in some commands/scripts that I found when reviewing the Mini-Project, I placed them in here so when we use `npm install` then it will install all packages/libraries for each `package.json` files (client, server and main) or when we utilize `npm run start` or `npm run build` it will run the associated commands for both the client and the server thanks to the `concurrently` devDependency.

The bulk changes were primarily made within `webpack.config.js` as after attempting to run the application (after doing `npm i` and `npm run start`) I was then receiving the following error that wasn't able to utilize/parse the contents of `style.css`:

<img width="587" alt="image" src="https://github.com/AegeanGrey/PWA-Text-Editor/assets/125229624/d148f81c-831e-47dc-894f-c496c7f97adb">

Taking this as a sign, I went to configure and add in the following to `webpack.config.js` based on how the same file within the Mini-Project was setup:

Plugins (Line 20)

- I added a new instance of the `HtmlWebpackPlugin` (Line 1 to Line 23) that uses it's stored library from `html-webpack-plugin` to generate the `index.html` file from the client folder and naming it `JATE` (Lines 24-25)

Note: Looking back at it, next push I will be renaming the `title` value from `JATE` (Line 25) to `J.A.T.E` next push as this is the proper title within `index.html` (Line 6).

- I added in a new instance of `InjectManifest` (Line 4 to Line 29) which uses the associated stored library from `workbox-webpack-plugin` to inject our custom service worker within `src-sq.js` file (Lines 30-31)

This allows us and the user to utilize the application while it's offline (to my understanding of service workers).

- I added a new instance of the `WebpackPwaManifest` (Line 2 to Line 35) which (again) uses it's associated stored library from `webpack-pwa-manifest` to create our `manifest.json` file that allows us to add in our CSS loaders and babel to webpack (more on that below) while providing proper sizing for our `logo.png` file (Lines 47-49).

The `manifest.json` we're creating also contains the initial URL we'd like to target/direct the page to load, background/theme colors and providing a name, short name and description for SEO utilization (Lines 35-45).

Module Rules (Line 57)

- I added in the CSS loaders that excludes the contents in `node_modules` and instead utilizes babel, their presets and provided plugins (Lines 57- 70)

All these changes to say I am still running into issues which prevents the application from starting that I will dissect until next push, but I believe I've added in the correct structure/contents of data that will be utilized to (eventually) run the application.