### PR TITLE
Added window prompt capabilities

### DIFF
--- a/client/src/js/install.js
+++ b/client/src/js/install.js
@@ -2,10 +2,36 @@ const butInstall = document.getElementById('buttonInstall');
 
 // Logic for installing the PWA
 // TODO: Add an event handler to the `beforeinstallprompt` event
-window.addEventListener('beforeinstallprompt', (event) => {});
+window.addEventListener('beforeinstallprompt', (event) => {
+  
+  // Store the triggered events
+  window.deferredPrompt = event;
+
+  // Remove the hidden class from the button.
+  butInstall.classList.toggle('hidden', false);
+});
 
 // TODO: Implement a click event handler on the `butInstall` element
-butInstall.addEventListener('click', async () => {});
+butInstall.addEventListener('click', async () => {
+ 
+  const promptEvent = window.deferredPrompt;
+
+  if (!promptEvent) {
+   return;
+  }
+
+  // Show prompt
+  promptEvent.prompt();
+  
+  // Reset the deferred prompt variable, it can only be used once.
+  window.deferredPrompt = null;
+  
+  butInstall.classList.toggle('hidden', true);
+});
 
 // TODO: Add an handler for the `appinstalled` event
-window.addEventListener('appinstalled', (event) => {});
+window.addEventListener('appinstalled', (event) => {
+    
+  // Clear prompt
+  window.deferredPrompt = null;
+});


### PR DESCRIPTION
This push allows the user to install their own instance of JATE onto their local machine! They can click an install icon in the top right of the URL and it will prompt them if they would like to install the application locally to exist in it's own window, and once done it also transfers their saved note data.

This was all thanks to the Mini-Project once again and it works perfectly.